### PR TITLE
Base64 Encode the value of the Cookie Consent library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,6 +857,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -920,6 +926,16 @@
         "electron-to-chromium": "^1.3.649",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.70"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-from": {
@@ -2338,6 +2354,12 @@
       "requires": {
         "safer-buffer": ">= 2.1.2 < 3"
       }
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true
     },
     "ignore": {
       "version": "5.1.8",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/mocha": "^8.2.0",
     "@types/sinon": "^9.0.10",
     "@types/sinon-chai": "^3.2.5",
+    "buffer": "^6.0.3",
     "chai": "^4.3.0",
     "chai-dom": "^1.8.2",
     "clean-webpack-plugin": "^3.0.0",

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,3 +1,13 @@
+import { CHCookie } from '../types'
+
 export const COOKIE_NAME = 'ch_cookie_consent'
 export const COOKIES = ['piwik', 'google']
 export const PUBLIC_SUFFIX_URLS = ['.service.gov.uk', '.gov.uk']
+export const ACCEPTED_COOKIE: CHCookie = {
+  userHasAllowedCookies: 'yes',
+  cookiesAllowed: COOKIES
+}
+export const REJECTED_COOKIE: CHCookie = {
+  userHasAllowedCookies: 'no',
+  cookiesAllowed: []
+}

--- a/src/cookie-management/index.ts
+++ b/src/cookie-management/index.ts
@@ -1,6 +1,8 @@
 import {
+  ACCEPTED_COOKIE,
   COOKIES,
-  COOKIE_NAME
+  COOKIE_NAME,
+  REJECTED_COOKIE
 } from '../constants'
 import { CHCookie } from '../types'
 import { getDomElements } from '../utilities/dom'
@@ -15,7 +17,9 @@ export function createCookie (value: CHCookie): void {
   const date = new Date()
   date.setTime(date.getTime() + (days * 24 * 60 * 60 * 1000))
   const expiryDate = date.toUTCString()
-  document.cookie = COOKIE_NAME + '=' + JSON.stringify(value) + '; expires=' + expiryDate + '; path=/; domain=' + setDomain()
+  const cookieValue = JSON.stringify(value)
+  const base64CookieValue = btoa(cookieValue)
+  document.cookie = COOKIE_NAME + '=' + base64CookieValue + '; expires=' + expiryDate + '; path=/; domain=' + setDomain()
 }
 
 /**
@@ -24,12 +28,8 @@ export function createCookie (value: CHCookie): void {
  */
 export function acceptCookies (callback: () => void): void {
   const { acceptOrRejectMessage, cookiesAcceptedMessage } = getDomElements()
-  const cookie: CHCookie = {
-    userHasAllowedCookies: 'yes',
-    cookiesAllowed: COOKIES
-  }
 
-  createCookie(cookie)
+  createCookie(ACCEPTED_COOKIE)
 
   if (acceptOrRejectMessage !== null) {
     acceptOrRejectMessage.hidden = true
@@ -56,12 +56,8 @@ export function rejectCookies (callback: () => void): void {
   }
 
   const { acceptOrRejectMessage, cookiesRejectedMessage } = getDomElements()
-  const cookie: CHCookie = {
-    userHasAllowedCookies: 'no',
-    cookiesAllowed: []
-  }
 
-  createCookie(cookie)
+  createCookie(REJECTED_COOKIE)
 
   if (acceptOrRejectMessage !== null) {
     acceptOrRejectMessage.hidden = true
@@ -80,7 +76,8 @@ export function getCookieObject (): CHCookie {
   for (const cookie of cookieArray) {
     if (cookie.includes(COOKIE_NAME)) {
       const cookieTuple = cookie.split('=')
-      return JSON.parse(cookieTuple[1]) as CHCookie
+      const decodedCookieValue = atob(cookieTuple[1])
+      return JSON.parse(decodedCookieValue) as CHCookie
     }
   }
 

--- a/tests/cookie-management/acceptCookies.test.ts
+++ b/tests/cookie-management/acceptCookies.test.ts
@@ -1,8 +1,7 @@
 import { spy, stub } from 'sinon'
 import { use, expect } from 'chai'
-import { createJSDOM } from '../test-utilities'
+import { createJSDOM, defaultAcceptedCookie } from '../test-utilities'
 import { acceptCookies } from '../../src'
-import { COOKIES, COOKIE_NAME } from '../../src/constants'
 import dirtyChai = require('dirty-chai')
 import sinonChai = require('sinon-chai')
 import chaiDom = require ('chai-dom')
@@ -12,8 +11,6 @@ use(sinonChai)
 use(chaiDom)
 
 const cleanup = createJSDOM()
-
-const defaultAcceptedCookie = `${COOKIE_NAME}={"userHasAllowedCookies":"yes","cookiesAllowed":${JSON.stringify(COOKIES)}}`
 
 describe('Accept Cookies tests', () => {
   afterEach(cleanup)

--- a/tests/cookie-management/createCookie.test.ts
+++ b/tests/cookie-management/createCookie.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
-import { createJSDOM, defaultHTML, defaultURL } from '../test-utilities'
+import { createJSDOM, defaultAcceptedCookie, defaultHTML, defaultURL } from '../test-utilities'
 import { createCookie } from '../../src/cookie-management'
-import { COOKIES, COOKIE_NAME } from '../../src/constants'
+import { COOKIES } from '../../src/constants'
 import { CHCookie } from '../../src/types'
 
 const cleanup = createJSDOM()
@@ -17,6 +17,6 @@ describe('Create cookie tests', () => {
 
     createCookie(cookie)
 
-    expect(document.cookie).to.contain(`${COOKIE_NAME}=${JSON.stringify(cookie)}`)
+    expect(document.cookie).to.contain(defaultAcceptedCookie)
   })
 })

--- a/tests/cookie-management/getCookieObject.test.ts
+++ b/tests/cookie-management/getCookieObject.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai'
-import { createJSDOM, defaultHTML, defaultURL } from '../test-utilities'
+import { createJSDOM, defaultAcceptedCookie, defaultHTML, defaultURL } from '../test-utilities'
 import { getCookieObject } from '../../src/cookie-management'
-import { COOKIES, COOKIE_NAME } from '../../src/constants'
+import { COOKIES } from '../../src/constants'
 import { CHCookie } from '../../src/types'
 import { CookieJar } from 'jsdom'
 
@@ -15,7 +15,7 @@ describe('Get cookie object tests', () => {
       cookiesAllowed: COOKIES
     }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(defaultAcceptedCookie, defaultURL, (x) => console.log)
     createJSDOM(defaultHTML, {
       url: defaultURL,
       cookieJar
@@ -32,7 +32,7 @@ describe('Get cookie object tests', () => {
       cookiesAllowed: COOKIES
     }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(defaultAcceptedCookie, defaultURL, (x) => console.log)
     cookieJar.setCookie('foo=bar', defaultURL, (x) => console.log)
     cookieJar.setCookie('bar=baz', defaultURL, (x) => console.log)
     createJSDOM(defaultHTML, {

--- a/tests/cookie-management/rejectCookies.test.ts
+++ b/tests/cookie-management/rejectCookies.test.ts
@@ -1,8 +1,7 @@
 import { spy, stub } from 'sinon'
 import { use, expect } from 'chai'
-import { createJSDOM } from '../test-utilities'
+import { createJSDOM, defaultRejectedCookie } from '../test-utilities'
 import { rejectCookies } from '../../src'
-import { COOKIE_NAME } from '../../src/constants'
 import dirtyChai = require('dirty-chai')
 import sinonChai = require('sinon-chai')
 import chaiDom = require ('chai-dom')
@@ -12,8 +11,6 @@ use(sinonChai)
 use(chaiDom)
 
 const cleanup = createJSDOM()
-
-const defaultRejectedCookie = `${COOKIE_NAME}={"userHasAllowedCookies":"no","cookiesAllowed":[]}`
 
 describe('Reject Cookies tests', () => {
   afterEach(cleanup)

--- a/tests/cookie-management/start.test.ts
+++ b/tests/cookie-management/start.test.ts
@@ -2,7 +2,7 @@ import { expect, use } from 'chai'
 import { CookieJar } from 'jsdom'
 import { spy, stub } from 'sinon'
 import { start } from '../../src/cookie-management'
-import { createJSDOM, defaultHTML, defaultURL } from '../test-utilities'
+import { base64Encode, createJSDOM, defaultAcceptedCookie, defaultHTML, defaultRejectedCookie, defaultURL } from '../test-utilities'
 import { CHCookie } from '../../src/types'
 import { COOKIES, COOKIE_NAME } from '../../src/constants'
 import chaiDom = require('chai-dom')
@@ -41,7 +41,7 @@ describe('Start function tests', () => {
       cookiesAllowed: [...COOKIES, 'newCookie']
     }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(`${COOKIE_NAME}=${base64Encode(JSON.stringify(cookie))}`, defaultURL, (x) => console.log)
     createJSDOM(defaultHTML, {
       url: defaultURL,
       cookieJar
@@ -64,12 +64,8 @@ describe('Start function tests', () => {
   })
 
   it('should call the callback if the user has allowed cookies but not show any dom elements', () => {
-    const cookie: CHCookie = {
-      userHasAllowedCookies: 'yes',
-      cookiesAllowed: COOKIES
-    }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(defaultAcceptedCookie, defaultURL, (x) => console.log)
     createJSDOM(defaultHTML, {
       url: defaultURL,
       cookieJar
@@ -92,12 +88,8 @@ describe('Start function tests', () => {
   })
 
   it('should not call the callback, or show any DOM elements if the user has rejected cookies', () => {
-    const cookie: CHCookie = {
-      userHasAllowedCookies: 'no',
-      cookiesAllowed: []
-    }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(defaultRejectedCookie, defaultURL, (x) => console.log)
     createJSDOM(defaultHTML, {
       url: defaultURL,
       cookieJar
@@ -120,12 +112,8 @@ describe('Start function tests', () => {
   })
 
   it('should log an error if the callback throws and not show any dom elements', () => {
-    const cookie: CHCookie = {
-      userHasAllowedCookies: 'yes',
-      cookiesAllowed: COOKIES
-    }
     const cookieJar = new CookieJar()
-    cookieJar.setCookie(`${COOKIE_NAME}=${JSON.stringify(cookie)}`, defaultURL, (x) => console.log)
+    cookieJar.setCookie(defaultAcceptedCookie, defaultURL, (x) => console.log)
 
     createJSDOM(defaultHTML, {
       url: defaultURL,

--- a/tests/test-utilities.ts
+++ b/tests/test-utilities.ts
@@ -1,5 +1,6 @@
 // Inspired by https://github.com/modosc/global-jsdom/blob/master/esm/index.mjs
 import { ConstructorOptions, JSDOM } from 'jsdom'
+import { ACCEPTED_COOKIE, COOKIE_NAME, REJECTED_COOKIE } from '../src/constants'
 
 export const defaultHTML = `
 <html lang="en">
@@ -43,3 +44,20 @@ export function createJSDOM (html = defaultHTML, options: ConstructorOptions = {
     }
   }
 }
+
+// These are needed as btoa and atob are not available in node
+export function base64Encode (value: string): string {
+  return Buffer.from(value, 'binary').toString('base64')
+}
+
+export function base64Decode (value: string): string {
+  return Buffer.from(value, 'base64').toString('binary')
+}
+
+const acceptedCookieJson = JSON.stringify(ACCEPTED_COOKIE)
+
+export const defaultAcceptedCookie = `${COOKIE_NAME}=${base64Encode(acceptedCookieJson)}`
+
+const rejectedCookieJson = JSON.stringify(REJECTED_COOKIE)
+
+export const defaultRejectedCookie = `${COOKIE_NAME}=${base64Encode(rejectedCookieJson)}`


### PR DESCRIPTION
This PR updates the Cookie Consent library to Base64 encode the value of the Cookie Consent JSON payload to allow legacy services to be able to correctly parse the cookie value.